### PR TITLE
Enum Fix

### DIFF
--- a/src/DOOM/p_spec.c
+++ b/src/DOOM/p_spec.c
@@ -151,7 +151,7 @@ void P_InitPicAnims(void)
 
     // Init animation
     lastanim = anims;
-    for (i = 0; animdefs[i].istexture != -1; i++)
+    for (i = 0; animdefs[i].istexture != (doom_boolean)-1; i++)
     {
         if (animdefs[i].istexture)
         {


### PR DESCRIPTION
gcc is treating enums as undefined by default. Since the invalid value in animdef_t is -1, it gets casted as 255 and fails to compare with -1 in P_InitPicAnims.