### PR TITLE
Fixed doom_getenv_impl() to return 0 instead implicitly returning

### DIFF
--- a/PureDOOM.h
+++ b/PureDOOM.h
@@ -7173,7 +7173,7 @@ char* doom_getenv_impl(const char* var)
     return getenv(var);
 }
 #else
-char* doom_getenv_impl(const char* var) {}
+char* doom_getenv_impl(const char* var) { return 0; }
 #endif
 
 

--- a/src/DOOM/DOOM.c
+++ b/src/DOOM/DOOM.c
@@ -191,7 +191,7 @@ char* doom_getenv_impl(const char* var)
     return getenv(var);
 }
 #else
-char* doom_getenv_impl(const char* var) {}
+char* doom_getenv_impl(const char* var) { return 0; }
 #endif
 
 


### PR DESCRIPTION
Fixed doom_getenv_impl() to return 0 instead implicitly returning