### PR TITLE
Fix allocating memory in zone under 64 bit

### DIFF
--- a/PureDOOM.h
+++ b/PureDOOM.h
@@ -48162,6 +48162,7 @@ void WI_Start(wbstartstruct_t* wbstartstruct)
 }
 #define ZONEID 0x1d4a11
 #define MINFRAGMENT 64
+#define MEM_ALIGN sizeof(void *)
 
 
 typedef struct
@@ -48301,7 +48302,7 @@ void* Z_Malloc(int size, int tag, void* user)
     memblock_t* newblock;
     memblock_t* base;
 
-    size = (size + 3) & ~3;
+    size = (size + MEM_ALIGN - 1) & ~(MEM_ALIGN - 1);
 
     // scan through the block list,
     // looking for the first free block

--- a/src/DOOM/z_zone.c
+++ b/src/DOOM/z_zone.c
@@ -43,6 +43,7 @@
 
 #define ZONEID 0x1d4a11
 #define MINFRAGMENT 64
+#define MEM_ALIGN sizeof(void *)
 
 
 typedef struct
@@ -182,7 +183,7 @@ void* Z_Malloc(int size, int tag, void* user)
     memblock_t* newblock;
     memblock_t* base;
 
-    size = (size + 3) & ~3;
+    size = (size + MEM_ALIGN - 1) & ~(MEM_ALIGN - 1);
 
     // scan through the block list,
     // looking for the first free block


### PR DESCRIPTION
Fixes #27 by using the size of a pointer to align anything allocated by the zone.