### PR TITLE
fix undefined behavior from signed int overflow

### DIFF
--- a/PureDOOM.h
+++ b/PureDOOM.h
@@ -39655,7 +39655,9 @@ void R_StoreWallRange(int start, int stop)
 
     // calculate rw_distance for scale calculation
     rw_normalangle = curline->angle + ANG90;
-    offsetangle = (angle_t)doom_abs((int)rw_normalangle - (int)rw_angle1);
+    offsetangle = rw_normalangle - rw_angle1;
+    if (offsetangle > ANG180)
+        offsetangle = -offsetangle;   // offsetangle = abs(rw_normalangle - rw_angle1)
 
     if (offsetangle > ANG90)
         offsetangle = ANG90;

--- a/src/DOOM/r_segs.c
+++ b/src/DOOM/r_segs.c
@@ -384,7 +384,9 @@ void R_StoreWallRange(int start, int stop)
 
     // calculate rw_distance for scale calculation
     rw_normalangle = curline->angle + ANG90;
-    offsetangle = (angle_t)doom_abs((int)rw_normalangle - (int)rw_angle1);
+    offsetangle = rw_normalangle - rw_angle1;
+    if (offsetangle > ANG180)
+        offsetangle = -offsetangle;   // offsetangle = abs(rw_normalangle - rw_angle1)
 
     if (offsetangle > ANG90)
         offsetangle = ANG90;


### PR DESCRIPTION
The Doom code uses unsigned BAM angles and relies on unsigned wraparound in its angle arithmetic. However, PureDOOM has the line

    offsetangle = (angle_t)doom_abs((int)rw_normalangle - (int)rw_angle1);

This casts the angles to signed integers and then does the subtraction. This is problematic because signed integer overflow is undefined behavior in C, and some compilers will emit incorrect code here. The correct code is the pattern already used a few pages further down in the `segtextured` section:

    offsetangle = rw_normalangle - rw_angle1;
    if (offsetangle > ANG180)
        offsetangle = -offsetangle;   // offsetangle = abs(rw_normalangle - rw_angle1)

This is not just academic, it produces actual rendering artifacts under some compilers which this PR fixes:

<img width="325" height="200" alt="image" src="https://github.com/user-attachments/assets/a98ef799-d667-4a29-969a-0e29ac4b798f" />
