### PR TITLE
use `(void)` for no-arg `doom_*` API functions

### DIFF
--- a/PureDOOM.h
+++ b/PureDOOM.h
@@ -189,18 +189,18 @@ void doom_set_getenv(doom_getenv_fn getenv_fn);
 void doom_init(int argc, char** argv, int flags);
 
 // Call this every frame
-void doom_update(); // This will update at 35 FPS
-void doom_force_update(); // This will run a frame everytime it's called, regardless of FPS.
+void doom_update(void); // This will update at 35 FPS
+void doom_force_update(void); // This will run a frame everytime it's called, regardless of FPS.
 
 // Channels: 1 = indexed, 3 = RGB, 4 = RGBA
 const unsigned char* doom_get_framebuffer(int channels);
 
 // It is always 2048 bytes in size
-short* doom_get_sound_buffer();
+short* doom_get_sound_buffer(void);
 
 // Call this 140 times per second. Or about every 7ms. 
 // Returns midi message. Keep calling it until it returns 0.
-unsigned long doom_tick_midi();
+unsigned long doom_tick_midi(void);
 
 // Events
 void doom_key_down(doom_key_t key);
@@ -7555,7 +7555,7 @@ void doom_init(int argc, char** argv, int flags)
 }
 
 
-void doom_update()
+void doom_update(void)
 {
     int now = I_GetTime();
     int delta_time = now - last_update_time;
@@ -7572,7 +7572,7 @@ void doom_update()
 }
 
 
-void doom_force_update()
+void doom_force_update(void)
 {
     if (is_wiping_screen)
         D_UpdateWipe();
@@ -7650,13 +7650,13 @@ const unsigned char* doom_get_framebuffer(int channels)
 }
 
 
-unsigned long doom_tick_midi()
+unsigned long doom_tick_midi(void)
 {
     return I_TickSong();
 }
 
 
-short* doom_get_sound_buffer()
+short* doom_get_sound_buffer(void)
 {
     I_UpdateSound();
     return mixbuffer;

--- a/src/DOOM/DOOM.c
+++ b/src/DOOM/DOOM.c
@@ -572,7 +572,7 @@ void doom_init(int argc, char** argv, int flags)
 }
 
 
-void doom_update()
+void doom_update(void)
 {
     int now = I_GetTime();
     int delta_time = now - last_update_time;
@@ -589,7 +589,7 @@ void doom_update()
 }
 
 
-void doom_force_update()
+void doom_force_update(void)
 {
     if (is_wiping_screen)
         D_UpdateWipe();
@@ -667,13 +667,13 @@ const unsigned char* doom_get_framebuffer(int channels)
 }
 
 
-unsigned long doom_tick_midi()
+unsigned long doom_tick_midi(void)
 {
     return I_TickSong();
 }
 
 
-short* doom_get_sound_buffer()
+short* doom_get_sound_buffer(void)
 {
     I_UpdateSound();
     return mixbuffer;

--- a/src/DOOM/DOOM.h
+++ b/src/DOOM/DOOM.h
@@ -189,18 +189,18 @@ void doom_set_getenv(doom_getenv_fn getenv_fn);
 void doom_init(int argc, char** argv, int flags);
 
 // Call this every frame
-void doom_update(); // This will update at 35 FPS
-void doom_force_update(); // This will run a frame everytime it's called, regardless of FPS.
+void doom_update(void); // This will update at 35 FPS
+void doom_force_update(void); // This will run a frame everytime it's called, regardless of FPS.
 
 // Channels: 1 = indexed, 3 = RGB, 4 = RGBA
 const unsigned char* doom_get_framebuffer(int channels);
 
 // It is always 2048 bytes in size
-short* doom_get_sound_buffer();
+short* doom_get_sound_buffer(void);
 
 // Call this 140 times per second. Or about every 7ms. 
 // Returns midi message. Keep calling it until it returns 0.
-unsigned long doom_tick_midi();
+unsigned long doom_tick_midi(void);
 
 // Events
 void doom_key_down(doom_key_t key);


### PR DESCRIPTION
The meaning of `()` changes across C standards and compiler versions, it can mean the function takes 0 args or an unspecified number of args. Prefer `(void)` to unambiguously declare 0-arg functions.